### PR TITLE
Resolve undefined method error with eager loading enabled

### DIFF
--- a/lib/hotwire-rails.rb
+++ b/lib/hotwire-rails.rb
@@ -5,4 +5,5 @@ require "turbo-rails"
 require "stimulus-rails"
 
 module Hotwire
+  extend ActiveSupport::Autoload
 end


### PR DESCRIPTION
Because:

The following error happened when deploying a Rails 6.1 app to staging, which had `config.eager_load = true`, but which didn't happen in local development:

```
gems/railties-6.1.0/lib/rails/application/finisher.rb:134:in `each': undefined method `eager_load!' for Hotwire:Module (NoMethodError)
from gems/railties-6.1.0/lib/rails/application/finisher.rb:134:in `block in <module:Finisher>'
```

Solution:

* Extend `ActiveSupport::Autoload`, like the `turbo-rails` gem does
* This provides the `eager_load!` method, app moves past this error

This is effectively the same as https://github.com/hotwired/stimulus-rails/pull/7.