### PR TITLE
docs: fix bare urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This gem installs both Turbo and Stimulus into your Rails application for use wi
 
 ## Usage
 
-See https://github.com/hotwired/turbo-rails and https://github.com/hotwired/stimulus-rails
+See <https://github.com/hotwired/turbo-rails> and <https://github.com/hotwired/stimulus-rails>
 
 
 ## License


### PR DESCRIPTION
Lint Markdown for MD034 Bare URL used

https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034---bare-url-used